### PR TITLE
Add module-info.java

### DIFF
--- a/svg-core/pom.xml
+++ b/svg-core/pom.xml
@@ -96,6 +96,36 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <!-- compile everything to ensure module-info contains right entries -->
+                            <!-- required when JAVA_HOME is JDK 8 or below -->
+                            <jdkToolchain>
+                                <version>9</version>
+                            </jdkToolchain>
+                            <release>9</release>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <!-- recompile everything for target VM except the module-info.java -->
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/svg-core/src/main/java/module-info.java
+++ b/svg-core/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+module com.kitfox.svg {
+    requires java.logging;
+    requires java.xml;
+    requires java.desktop;
+
+    requires static ant;
+
+    exports com.kitfox.svg;
+    exports com.kitfox.svg.animation;
+    exports com.kitfox.svg.app;
+    exports com.kitfox.svg.app.ant;
+    exports com.kitfox.svg.app.beans;
+    exports com.kitfox.svg.app.data;
+    exports com.kitfox.svg.xml;
+}


### PR DESCRIPTION
Add a module info descriptor and setup maven to compile it using Java 9.
All remaining sources are still compiled with Java 8 compatibility.

I wasn't sure about which module name to choose so for now it is `com.kitfox.svg`. However to not get into conflict with the upstream repository I could also imagine using `com.formdev.svgsalamander`.

Also the explicit `exports` statements are just an estimate about what is actually used by consumers of the library. An option would be to just export all packages and also declare the module as `open` such that all reflective operations are permitted.